### PR TITLE
feat: add makefile recipes for installing apt packages from yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: install-apt-packages requirements-for-installing-apt-packages
+
+UBUNTU_RELEASE_CODENAME != cat /etc/lsb-release | grep DISTRIB_CODENAME | cut -f2 -d=
+
+requirements-for-installing-apt-packages:
+	sudo add-apt-repository "deb https://ppa.launchpadcontent.net/rmescandon/yq/ubuntu $(UBUNTU_RELEASE_CODENAME) main"
+	sudo apt install yq
+
+install-apt-packages: requirements-for-installing-apt-packages
+	yq eval '.packages[]' apt-package-list.yaml | xargs sudo apt install

--- a/apt-package-list.yaml
+++ b/apt-package-list.yaml
@@ -1,0 +1,2 @@
+packages:
+- xsel # particularly relevant for copying and pasting out of emacs


### PR DESCRIPTION
this will give me a space to document system-level dependencies while making it fairly easy to install them all in one go

heard about the ppa for yq (which, snap-only? really?) from [here](https://github.com/mikefarah/yq/issues/480#issuecomment-1057046481)