### PR TITLE
feat: switch to using virtualenvwrapper via pyenv plugin

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -27,9 +27,10 @@ bashcompinit
 if [[ -x "$(command -v pyenv)" ]]; then
     eval "$(pyenv init -)"
 
-    if [[ -x "$(command -v virtualenvwrapper.sh)" ]]; then
+    if [[ -d "$(pyenv root)/plugins/pyenv-virtualenvwrapper" ]]; then
         export WORKON_HOME=$HOME/.virtualenvs
-        source virtualenvwrapper.sh
+        export VIRTUALENVWRAPPER_PYTHON=/home/matt/.pyenv/shims/python3
+        pyenv virtualenvwrapper
     fi
 fi
 


### PR DESCRIPTION
specifically this plugin: https://github.com/pyenv/pyenv-virtualenvwrapper

Nota bene that the directory we check for in shell setup I created with:
```sh
git clone git@github.com:pyenv/pyenv-virtualenvwrapper.git $(pyenv root)/plugins/pyenv-virtualenvwrapper
```